### PR TITLE
Don't store current chain id in storage

### DIFF
--- a/contracts/mock/MockDeBridgeGate.sol
+++ b/contracts/mock/MockDeBridgeGate.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.2;
 
 import "../transfers/DeBridgeGate.sol";
 
-contract MockDeBridgeGate is DeBridgeGate{
+contract MockDeBridgeGate is DeBridgeGate {
+
+    uint256 public chainId;
 
     /* ========== CONSTRUCTOR  ========== */
 
@@ -56,5 +58,10 @@ contract MockDeBridgeGate is DeBridgeGate{
         treasury = _treasury;
 
         flashFeeBps = 10;
+    }
+
+    // return overrided chain id
+    function getChainId() override public view returns (uint256 cid) {
+        return chainId;
     }
 }

--- a/contracts/mock/MockDeBridgeGateForDefiController.sol
+++ b/contracts/mock/MockDeBridgeGateForDefiController.sol
@@ -3,11 +3,10 @@ pragma solidity ^0.8.2;
 
 import "../transfers/DeBridgeGate.sol";
 
-contract MockDeBridgeGateForDefiController is DeBridgeGate{
+contract MockDeBridgeGateForDefiController is DeBridgeGate {
 
     function init() external {
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        chainId = 1;
     }
 
     function sendETH() payable external {}
@@ -33,5 +32,10 @@ contract MockDeBridgeGateForDefiController is DeBridgeGate{
         debridge.minReservesBps = minReservesBps;
         debridge.getChainFee[chainId] = chainFee;
         debridge.exist = exist;
+    }
+
+    // override chain id
+    function getChainId() override public pure returns (uint256 cid) {
+        return 1;
     }
 }

--- a/test/01_FullDebridge.test.js
+++ b/test/01_FullDebridge.test.js
@@ -357,7 +357,7 @@ contract("DeBridgeGate full mode", function () {
         const amount = toBN(1000);
         const flashFeeBps = await this.debridge.flashFeeBps();
         const fee = amount.mul(flashFeeBps).div(BPS);
-        const chainId = await this.debridge.chainId();
+        const chainId = await this.debridge.getChainId();
         const debridgeId = await this.debridge.getDebridgeId(chainId, this.mockToken.address);
         const debridge = await this.debridge.getDebridge(debridgeId);
         const paidBefore = debridge.collectedFees;
@@ -488,7 +488,7 @@ contract("DeBridgeGate full mode", function () {
             });
 
             it("should confirm new asset if called by the oracles", async function () {
-              currentChainId = await this.debridge.chainId();
+              currentChainId = await this.debridge.getChainId();
               // todo: what's address? Should be taken from fixture.
               const chainId = 56;
               const maxAmount = toWei("1000000");
@@ -540,7 +540,7 @@ contract("DeBridgeGate full mode", function () {
                 const amountThreshold = toWei("10");
 
                 receiver = bob.address;
-                currentChainId = await this.debridge.chainId();
+                currentChainId = await this.debridge.getChainId();
                 const newSupply = toWei("100");
                 await this.linkToken.mint(alice.address, newSupply, {
                   from: alice.address,
@@ -854,7 +854,7 @@ contract("DeBridgeGate full mode", function () {
 
                         it("should reject burning from current chain", async function () {
                           const tokenAddress = ZERO_ADDRESS;
-                          const chainId = await this.debridge.chainId();
+                          const chainId = await this.debridge.getChainId();
                           const receiver = bob.address;
                           const amount = toBN(toWei("1"));
                           const debridgeId = await this.debridge.getDebridgeId(
@@ -901,7 +901,7 @@ contract("DeBridgeGate full mode", function () {
               let erc20Submission;
               beforeEach(async function () {
                 receiver = bob.address;
-                chainId = await this.debridge.chainId();
+                chainId = await this.debridge.getChainId();
                 debridgeId = await this.debridge.getDebridgeId(chainId, tokenAddress);
                 outsideDebridgeId = await this.debridge.getDebridgeId(56, this.mockToken.address);
                 erc20DebridgeId = await this.debridge.getDebridgeId(
@@ -1075,7 +1075,7 @@ contract("DeBridgeGate full mode", function () {
                     expect(discount).to.equal(discountFromContract.discountFixBps);
 
                     const tokenAddress = ZERO_ADDRESS;
-                    const chainId = await this.debridge.chainId();
+                    const chainId = await this.debridge.getChainId();
                     const receiver = bob.address;
                     const amount = toBN(toWei("1"));
                     const chainIdTo = 42;
@@ -1103,7 +1103,7 @@ contract("DeBridgeGate full mode", function () {
                   beforeEach(async function () {
                     let discount = 0;
                     const tokenAddress = this.mockToken.address;
-                    const chainId = await this.debridge.chainId();
+                    const chainId = await this.debridge.getChainId();
                     const receiver = bob.address;
                     const amount = toBN(toWei("100"));
                     const chainIdTo = 42;
@@ -1171,7 +1171,7 @@ contract("DeBridgeGate full mode", function () {
                     const submissionId = await this.debridge.getSubmisionId(
                       erc20DebridgeId,
                       chainIdFrom,
-                      await this.debridge.chainId(),
+                      await this.debridge.getChainId(),
                       amount,
                       receiver,
                       nonce
@@ -1231,7 +1231,7 @@ contract("DeBridgeGate full mode", function () {
                       const submissionId = await this.debridge.getSubmisionId(
                         debridgeId,
                         chainIdFrom,
-                        await this.debridge.chainId(),
+                        await this.debridge.getChainId(),
                         amount,
                         receiver,
                         nonce
@@ -1281,7 +1281,7 @@ contract("DeBridgeGate full mode", function () {
 
                 it("should send native tokens from the current chain", async function () {
                   const tokenAddress = ZERO_ADDRESS;
-                  const chainId = await this.debridge.chainId();
+                  const chainId = await this.debridge.getChainId();
                   const receiver = bob.address;
                   const amount = toBN(toWei("1"));
                   const chainIdTo = 42;
@@ -1308,7 +1308,7 @@ contract("DeBridgeGate full mode", function () {
 
                 it("should send ERC20 tokens from the current chain", async function () {
                   const tokenAddress = this.mockToken.address;
-                  const chainId = await this.debridge.chainId();
+                  const chainId = await this.debridge.getChainId();
                   const receiver = bob.address;
                   const amount = toBN(toWei("100"));
                   const chainIdTo = 42;
@@ -1342,7 +1342,7 @@ contract("DeBridgeGate full mode", function () {
                 });
                 it("should send ERC20 tokens from the current chain (_useAssetFee=true)", async function () {
                   const tokenAddress = this.mockToken.address;
-                  const chainId = await this.debridge.chainId();
+                  const chainId = await this.debridge.getChainId();
                   const receiver = bob.address;
                   const amount = toBN(toWei("100"));
                   const chainIdTo = 42;
@@ -1392,7 +1392,7 @@ contract("DeBridgeGate full mode", function () {
                 it("should reverts if amount more than maxAmount", async function () {
                   const tokenAddress = ZERO_ADDRESS;
                   const receiver = bob.address;
-                  const chainId = await this.debridge.chainId();
+                  const chainId = await this.debridge.getChainId();
                   const amount = toWei("20");
                   const chainIdTo = 42;
 
@@ -1419,7 +1419,7 @@ contract("DeBridgeGate full mode", function () {
                 it("should reject sending too mismatched amount of native tokens", async function () {
                   const tokenAddress = ZERO_ADDRESS;
                   const receiver = bob.address;
-                  const chainId = await this.debridge.chainId();
+                  const chainId = await this.debridge.getChainId();
                   const amount = toBN(toWei("1"));
                   const chainIdTo = 42;
                   const debridgeId = await this.debridge.getDebridgeId(chainId, tokenAddress);
@@ -1435,7 +1435,7 @@ contract("DeBridgeGate full mode", function () {
                 it("should reject sending tokens to unsupported chain", async function () {
                   const tokenAddress = ZERO_ADDRESS;
                   const receiver = bob.address;
-                  const chainId = await this.debridge.chainId();
+                  const chainId = await this.debridge.getChainId();
                   const amount = toBN(toWei("1"));
                   const chainIdTo = chainId;
                   const debridgeId = await this.debridge.getDebridgeId(chainId, tokenAddress);

--- a/test/02_LightDebridge.test.js
+++ b/test/02_LightDebridge.test.js
@@ -349,7 +349,7 @@ contract("DeBridgeGate light mode", function() {
   context("Test send method", () => {
     it("should send native tokens from the current chain", async function() {
       const tokenAddress = ZERO_ADDRESS;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const receiver = bob;
       const amount = toBN(toWei("1"));
       const chainIdTo = 42;
@@ -388,7 +388,7 @@ contract("DeBridgeGate light mode", function() {
 
     it("should send ERC20 tokens from the current chain", async function() {
       const tokenAddress = this.mockToken.address;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const receiver = bob;
       const amount = toBN(toWei("100"));
       const chainIdTo = 42;
@@ -443,7 +443,7 @@ contract("DeBridgeGate light mode", function() {
     it("should reject sending too mismatched amount of native tokens", async function() {
       const tokenAddress = ZERO_ADDRESS;
       const receiver = bob;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const amount = toBN(toWei("1"));
       const chainIdTo = 42;
       const debridgeId = await this.debridge.getDebridgeId(
@@ -462,7 +462,7 @@ contract("DeBridgeGate light mode", function() {
     it("should reject sending tokens to unsupported chain", async function() {
       const tokenAddress = ZERO_ADDRESS;
       const receiver = bob;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const amount = toBN(toWei("1"));
       const chainIdTo = chainId;
       const debridgeId = await this.debridge.getDebridgeId(
@@ -492,7 +492,7 @@ contract("DeBridgeGate light mode", function() {
       receiver = bob;
       debridgeId = await this.debridge.getDebridgeId(chainId, tokenAddress);
       //console.log('debridgeId '+debridgeId);
-      currentChainId = await this.debridge.chainId();
+      currentChainId = await this.debridge.getChainId();
       const submission = await this.debridge.getSubmisionId(
         debridgeId,
         chainId,
@@ -682,7 +682,7 @@ contract("DeBridgeGate light mode", function() {
 
     it("should reject burning from current chain", async function() {
       const tokenAddress = ZERO_ADDRESS;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const receiver = bob;
       const amount = toBN(toWei("1"));
       const debridgeId = await this.debridge.getDebridgeId(
@@ -763,7 +763,7 @@ contract("DeBridgeGate light mode", function() {
 
     before(async function() {
       receiver = bob;
-      chainId = await this.debridge.chainId();
+      chainId = await this.debridge.getChainId();
       debridgeId = await this.debridge.getDebridgeId(chainId, tokenAddress);
       erc20DebridgeId = await this.debridge.getDebridgeId(
         chainId,

--- a/test/04_AutoFullDebridge.test.js
+++ b/test/04_AutoFullDebridge.test.js
@@ -247,7 +247,7 @@ contract("DeBridgeGate full with auto", function () {
 
   context("Test managing assets", () => {
     before(async function() {
-      currentChainId = await this.debridge.chainId();
+      currentChainId = await this.debridge.getChainId();
       const newSupply = toWei("100");
       await this.linkToken.mint(alice, newSupply, {
         from: alice,
@@ -329,7 +329,7 @@ contract("DeBridgeGate full with auto", function () {
   context("Test send method", () => {
     it("should send native tokens from the current chain", async function() {
       const tokenAddress = ZERO_ADDRESS;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const receiver = bob;
       const amount = toBN(toWei("1"));
       const chainIdTo = 42;
@@ -371,7 +371,7 @@ contract("DeBridgeGate full with auto", function () {
 
     it("should send ERC20 tokens from the current chain", async function() {
       const tokenAddress = this.mockToken.address;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const receiver = bob;
       const amount = toBN(toWei("100"));
       const chainIdTo = 42;
@@ -429,7 +429,7 @@ contract("DeBridgeGate full with auto", function () {
     it("should reject sending too mismatched amount of native tokens", async function() {
       const tokenAddress = ZERO_ADDRESS;
       const receiver = bob;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const amount = toBN(toWei("1"));
       const chainIdTo = 42;
       const debridgeId = await this.debridge.getDebridgeId(
@@ -452,7 +452,7 @@ contract("DeBridgeGate full with auto", function () {
     it("should reject sending tokens to unsupported chain", async function() {
       const tokenAddress = ZERO_ADDRESS;
       const receiver = bob;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const amount = toBN(toWei("1"));
       const chainIdTo = chainId;
       const debridgeId = await this.debridge.getDebridgeId(
@@ -482,7 +482,7 @@ contract("DeBridgeGate full with auto", function () {
     let currentChainId;
     before(async function() {
       receiver = bob
-      currentChainId = await this.debridge.chainId();
+      currentChainId = await this.debridge.getChainId();
       const newSupply = toWei("100");
       await this.linkToken.mint(alice, newSupply, {
         from: alice,
@@ -704,7 +704,7 @@ contract("DeBridgeGate full with auto", function () {
 
     it("should reject burning from current chain", async function() {
       const tokenAddress = ZERO_ADDRESS;
-      const chainId = await this.debridge.chainId();
+      const chainId = await this.debridge.getChainId();
       const receiver = bob;
       const amount = toBN(toWei("1"));
       const debridgeId = await this.debridge.getDebridgeId(
@@ -746,7 +746,7 @@ contract("DeBridgeGate full with auto", function () {
     let erc20DebridgeId;
     before(async function() {
       receiver = bob
-      chainId = await this.debridge.chainId();
+      chainId = await this.debridge.getChainId();
       debridgeId = await this.debridge.getDebridgeId(chainId, tokenAddress);
       outsideDebridgeId = await this.debridge.getDebridgeId(
         56,
@@ -815,7 +815,7 @@ contract("DeBridgeGate full with auto", function () {
       const submissionId = await this.debridge.getAutoSubmisionId(
         debridgeId,
         chainIdFrom,
-        await this.debridge.chainId(),
+        await this.debridge.getChainId(),
         amount,
         receiver,
         nonce,
@@ -856,7 +856,7 @@ contract("DeBridgeGate full with auto", function () {
       const submissionId = await this.debridge.getAutoSubmisionId(
         erc20DebridgeId,
         chainIdFrom,
-        await this.debridge.chainId(),
+        await this.debridge.getChainId(),
         amount,
         receiver,
         nonce,


### PR DESCRIPTION
Don't store current chainId in storage variable and use getChainId method instead.
CHAINID opcode gas cost - 2
SLOAD (Load word from storage) gas cost - 800

Contract size before: 22.37
Contract size after: 22.30

Gas usage before:
![image](https://user-images.githubusercontent.com/2185523/130057498-8e19266e-1417-4dfe-b7d7-c7a3b5fb3731.png)

Gas usage after:
![image](https://user-images.githubusercontent.com/2185523/130057597-448aba5c-0fa4-4b8c-a7ba-840bbd660544.png)
