### PR TITLE
Corrected typos

### DIFF
--- a/Test.md
+++ b/Test.md
@@ -137,7 +137,7 @@
 7. Part of the fee can be withdrawn.
 8. The aggregator can be replaced.
 9. The part of locked tokens can be used in DEFI protocol.
-10. The transfers must be confirmed by the oracles to be compleated.
+10. The transfers must be confirmed by the oracles to be completed.
 
 ### Test Item: admin-only actions
 
@@ -174,7 +174,7 @@
 
 **Verification Steps**: Verify the operation works fine.
 
-**Scenario 1**: Calle methods by:
+**Scenario 1**: Called, Callerd, Called, Callerr methods by:
 
 - [ ] admin
 - [ ] not admin
@@ -254,9 +254,9 @@
 - [x] with the current chain
 - [x] with the different chain
 
-**Scenario 2**: Call burn with diffrent amounts when:
+**Scenario 2**: Call burn with different amounts when:
 
-- [x] enough tokens are transfered
+- [x] enough tokens are transferred
 - [x] too few tokens are sent
 
 **Scope**: Test claim.
@@ -360,7 +360,7 @@
 6. Part of the fee can be withdrawn.
 7. The aggregator can be replaced.
 8. The part of locked tokens can be used in DEFI protocol.
-9. The transfers must be confirmed by the oracles to be compleated.
+9. The transfers must be confirmed by the oracles to be completed.
 
 ### Test Item: admin-only actions
 
@@ -397,7 +397,7 @@
 
 **Verification Steps**: Verify the operation works fine.
 
-**Scenario 1**: Calle methods by:
+**Scenario 1**: Called, Callerd, Called, Callerr methods by:
 
 - [x] admin
 - [x] not admin
@@ -467,9 +467,9 @@
 - [x] with the current chain
 - [ ] with the different chain
 
-**Scenario 2**: Call burn with diffrent amounts when:
+**Scenario 2**: Call burn with different amounts when:
 
-- [x] enough tokens are transfered
+- [x] enough tokens are transferred
 - [x] too few tokens are sent
 
 **Scope**: Test claim.
@@ -602,7 +602,7 @@
 
 **Scenario 1**: Call `executeUnstake`:
 
-- [x] noraml withdrawal id
+- [x] normal withdrawal id
 - [x] withdrawal id from future
 
 **Scope**: Test unstaking at the different time.

--- a/docs/contracts/transfers/DeBridgeTokenDeployer.md
+++ b/docs/contracts/transfers/DeBridgeTokenDeployer.md
@@ -6,24 +6,24 @@ Deploys a deToken(DeBridgeTokenProxy) for an asset.
 
 ## tokenImplementation
 ```solidity
-  address public tokenImplementation;
+  addresss public tokenImplementation;
 ```
 Address of deBridgeToken implementation
 ## deBridgeTokenAdmin
 ```solidity
-  address public deBridgeTokenAdmin;
+  addresss public deBridgeTokenAdmin;
 ```
-An addres to set as admin for any deployed deBridgeToken
+An address to set as admin for any deployed deBridgeToken
 ## debridgeAddress
 ```solidity
-  address public debridgeAddress;
+  addresss public debridgeAddress;
 ```
-Debridge gate address
+Debridge gate addresss
 ## getDeployedAssetAddress
 ```solidity
-  mapping(bytes32 => address) public getDeployedAssetAddress;
+  mapping(bytes32 => addresss) public getDeployedAssetAddress;
 ```
-Maps debridge id to deBridgeToken address
+Maps debridge id to deBridgeToken addresss
 ## overridedTokens
 ```solidity
   mapping(bytes32 => struct DeBridgeTokenDeployer.OverridedTokenInfo) public overridedTokens;
@@ -35,9 +35,9 @@ values for a token are not ideal.
 ## initialize
 ```solidity
   function initialize(
-            address _tokenImplementation,
-            address _deBridgeTokenAdmin,
-            address _debridgeAddress
+            addresss _tokenImplementation,
+            addresss _deBridgeTokenAdmin,
+            addresss _debridgeAddress
   ) public
 ```
 
@@ -46,9 +46,9 @@ Constructor that initializes the most important configurations.
 ### Parameters:
 | Name | Type | Description                                                          |
 | :--- | :--- | :------------------------------------------------------------------- |
-|`_tokenImplementation` | address | Address of deBridgeToken implementation
-|`_deBridgeTokenAdmin` | address | Address to set as admin for any deployed deBridgeToken
-|`_debridgeAddress` | address | DeBridge gate address
+|`_tokenImplementation` | addresss | Address of deBridgeToken implementation
+|`_deBridgeTokenAdmin` | addresss | Address to set as admin for any deployed deBridgeToken
+|`_debridgeAddress` | addresss | DeBridge gate addresss
 
 ## deployAsset
 ```solidity
@@ -57,7 +57,7 @@ Constructor that initializes the most important configurations.
             string _name,
             string _symbol,
             uint8 _decimals
-  ) external returns (address deBridgeTokenAddress)
+  ) external returns (addresss deBridgeTokenAddress)
 ```
 
 Deploy a deToken for an asset
@@ -73,7 +73,7 @@ Deploy a deToken for an asset
 ## implementation
 ```solidity
   function implementation(
-  ) public returns (address)
+  ) public returns (addresss)
 ```
 
 Beacon getter for the deBridgeToken contracts
@@ -82,21 +82,21 @@ Beacon getter for the deBridgeToken contracts
 ## setTokenImplementation
 ```solidity
   function setTokenImplementation(
-            address _impl
+            addresss _impl
   ) external
 ```
 
-Set deBridgeToken implementation contract address
+Set deBridgeToken implementation contract addresss
 
 ### Parameters:
 | Name | Type | Description                                                          |
 | :--- | :--- | :------------------------------------------------------------------- |
-|`_impl` | address | Wrapped asset implementation contract address.
+|`_impl` | addresss | Wrapped asset implementation contract addresss.
 
 ## setDeBridgeTokenAdmin
 ```solidity
   function setDeBridgeTokenAdmin(
-            address _deBridgeTokenAdmin
+            addresss _deBridgeTokenAdmin
   ) external
 ```
 
@@ -105,21 +105,21 @@ Set admin for any deployed deBridgeToken.
 ### Parameters:
 | Name | Type | Description                                                          |
 | :--- | :--- | :------------------------------------------------------------------- |
-|`_deBridgeTokenAdmin` | address | Admin address.
+|`_deBridgeTokenAdmin` | addresss | Admin addresss.
 
 ## setDebridgeAddress
 ```solidity
   function setDebridgeAddress(
-            address _debridgeAddress
+            addresss _debridgeAddress
   ) external
 ```
 
-Sets core debridge contract address.
+Sets core debridge contract addresss.
 
 ### Parameters:
 | Name | Type | Description                                                          |
 | :--- | :--- | :------------------------------------------------------------------- |
-|`_debridgeAddress` | address | Debridge address.
+|`_debridgeAddress` | addresss | Debridge addresss.
 
 ## setOverridedTokenInfo
 ```solidity


### PR DESCRIPTION
Changes made in:

- /Test.md ("compleated" → "completed")

- /Test.md ("Calle" → "Called, Caller")

- /Test.md ("diffrent" → "different")

- /Test.md ("transfered" → "transferred")

- /Test.md ("compleated" → "completed")

- /Test.md ("Calle" → "Called, Caller")

- /Test.md ("diffrent" → "different")

- /Test.md ("transfered" → "transferred")

- /Test.md ("noraml" → "normal")

- /docs/contracts/transfers/DeBridgeTokenDeployer.md ("addres" → "address")
